### PR TITLE
Add atmega32u4 crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A list of useful AVR libraries and cool projects
 # Libraries
 
 * [AVR device library](https://github.com/avr-rust/avrd) ([crates.io](https://crates.io/crates/avrd)) ([docs.rs](https://docs.rs/avrd/))
-* [Trimmed down libcore for AVR](https://github.com/gergoerdi/rust-avr-libcore-mini)
+* [Trimmed down libcore for AVR](https://github.com/gergoerdi/rust-avr-libcore-mini) (_No longer necessary_)
 
 # Projects
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A list of useful AVR libraries and cool projects
 
 * [AVR device library](https://github.com/avr-rust/avrd) ([crates.io](https://crates.io/crates/avrd)) ([docs.rs](https://docs.rs/avrd/))
 * [Trimmed down libcore for AVR](https://github.com/gergoerdi/rust-avr-libcore-mini) (_No longer necessary_)
+* [`atmega32u4`](https://github.com/Rahix/atmega32u4) & [`atmega32u4-hal`](https://github.com/Rahix/atmega32u4-hal) - `embedded-hal` crates for `atmega32u4`
+* [`arduino-leonardo`](https://github.com/Rahix/arduino-leonardo) - Board Support Crate for Arduino Leonardo
 
 # Projects
 


### PR DESCRIPTION
Hey @dylanmckay, sorry for the late response ...

As you requested, I added my crates to this list.  I also marked the libcore fork as deprecated because we no longer need it.