### PR TITLE
Add avr-device & avr-hal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A list of useful AVR libraries and cool projects
 
 * [AVR device library](https://github.com/avr-rust/avrd) ([crates.io](https://crates.io/crates/avrd)) ([docs.rs](https://docs.rs/avrd/))
 * [Trimmed down libcore for AVR](https://github.com/gergoerdi/rust-avr-libcore-mini) (_No longer necessary_)
-* [`atmega32u4`](https://github.com/Rahix/atmega32u4) & [`atmega32u4-hal`](https://github.com/Rahix/atmega32u4-hal) - `embedded-hal` crates for `atmega32u4`
+* [`avr-device`](https://github.com/Rahix/avr-device) & [`avr-hal`](https://github.com/Rahix/avr-hal) - `embedded-hal` implementations for AVR microcontrollers
+  * (deprecated) [`atmega32u4`](https://github.com/Rahix/atmega32u4) & [`atmega32u4-hal`](https://github.com/Rahix/atmega32u4-hal) - `embedded-hal` crates for `atmega32u4`
 * [`arduino-leonardo`](https://github.com/Rahix/arduino-leonardo) - Board Support Crate for Arduino Leonardo
 
 # Projects


### PR DESCRIPTION
Looking at the `atmega32u4` / `atmega32u4-hal` repos, both are deprecated in favour of the more generic implementations: `avr-device` / `avr-hal`.