### PR TITLE
Added AVRoxide to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ A list of useful AVR libraries and cool projects
 * [Demo for Arduboy](https://github.com/simon-i1-h/arduboy-hello-rs)
 * [Dockerized avr-rust toolchain by Douglas Campos](https://github.com/qmx/docker-avr-rust)
 * [LED Blink Example](https://github.com/avr-rust/blink/)
+* [AVRoxide](https://avroxi.de), a runtime [crate](https://crates.io/crates/avr-oxide) for ATmega4809 (including Arduino Nano Every)


### PR DESCRIPTION
Hi,

I added my ATmega4809 runtime project to the list of Rust AVR projects, I hope that's OK.  I think it's at a stage where it's actually ready to be usable for something :-).

Best regards,
Tim